### PR TITLE
Update listener.php

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -110,7 +110,7 @@ class listener implements EventSubscriberInterface
 				'WARNING_TIME'		=> ($row['warning_end']) ? $this->user->format_date($row['warning_end']) : $this->user->lang['PERMANENT'],
 				'WARNING'			=> $warning[0],
 				'WARNINGS'			=> $this->user->format_date($row['warning_time']),
-				'WARNING_STATUS'	=> ($row['warning_status']) ? true : false,
+				'WARNING_STATUS'	=> ($row['warning_status'] && $this->auth->acl_get('m_warn')) ? true : false,
 				'WARNING_TYPE'		=> ($row['warning_type'] == self::BAN) ? $this->user->lang['BAN'] : $this->user->lang['WARNING'],
 				'U_WARNING_POST_URL'=> ($row['post_id']) ? append_sid("{$this->phpbb_root_path}viewtopic.$this->php_ext", 'p=' . $row['post_id'] . '#p' . $row['post_id']) : '',
 			);


### PR DESCRIPTION
Обновление поля статуса: редактировать предупреждения могут только модераторы.
Исправление этой ошибки:
![link_memberlist_warnings_fix](https://cloud.githubusercontent.com/assets/7805635/3634452/d0ba4862-0f2f-11e4-85c2-e5aa2358ddd6.png)
Скриншот при входе в свой профиль пользователя test, не имеющего права редактировать предупреждения.
