### PR TITLE
Update warnings text and ban text style

### DIFF
--- a/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_before.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_before.html
@@ -1,1 +1,1 @@
-<!-- IF postrow.POSTER_BANNED --><br /><dd style="background-color: #ECD5D8;"><strong>{L_BANNED}:</strong> {postrow.POSTER_BAN_END}<!-- ELSEIF postrow.POSTER_WARNINGS --><dd style="background-color: #FFFF99;"><strong>{L_WARNINGS}:</strong> {postrow.POSTER_WARNINGS}</dd><!-- ENDIF -->
+<!-- IF postrow.POSTER_BANNED --><br /><dd style="background-color: #bc2a4d; color: #fff; padding: 2px 0; text-align: center;">{L_BANNED}{L_COLON} {postrow.POSTER_BAN_END}<!-- ENDIF -->

--- a/styles/prosilver/template/event/viewtopic_body_postrow_post_notices_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_post_notices_after.html
@@ -1,1 +1,1 @@
-<!-- IF postrow.WARNING --><div class="notice"><strong><!-- IF postrow.WARNING_TYPE eq 1 -->{L_BAN}<!-- ELSE -->{L_WARNING}<!-- ENDIF -->:</strong> {postrow.WARNING_POSTER} {postrow.WARNING_TIME}<br /><strong>{L_REASON}:</strong><em>{postrow.WARNING}</em></div><!-- ENDIF -->
+<!-- IF postrow.WARNING --><div class="notice"><strong><!-- IF postrow.WARNING_TYPE eq 1 -->{L_BAN}<!-- ELSE -->{L_WARNING}<!-- ENDIF -->{L_COLON}</strong> {postrow.WARNING_POSTER} {postrow.WARNING_TIME}<br /><strong>{L_REASON}{L_COLON}</strong> <em>{postrow.WARNING}</em></div><!-- ENDIF -->


### PR DESCRIPTION
Исправлено:
- дублирование строки с числом предупреждений в минипрофиле;
- отсутствие пробела после двоеточия в строке причины;
- использование двоеточий вместо {L_COLON};
- дизайн строки "забанен".

Старый вариант виден на скриншоте.
![warnings_text_fix](https://cloud.githubusercontent.com/assets/7805635/3660898/e940e06a-11bb-11e4-8494-8f6802127e9d.png)
