### PR TITLE
Several fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - SNIFF="1"            # Should we run code sniffer on your code?
     - IMAGE_ICC="1"        # Should we run icc profile sniffer on your images?
     - EPV="1"              # Should we run EPV (Extension Pre Validator) on your code?
-    - PHPBB_BRANCH="develop-ascraeus"
+    - PHPBB_BRANCH="3.1.x"
 
 branches:
   only:
@@ -48,7 +48,7 @@ before_install:
   - sudo rm -rf phpbb-ext-acme-demo
 
 install:
-  - composer install --dev --no-interaction --prefer-source
+  - travis_retry composer install --dev --no-interaction --prefer-source
   - travis/prepare-phpbb.sh $EXTNAME $PHPBB_BRANCH
   - cd ../../phpBB3
   - travis/prepare-extension.sh $EXTNAME $PHPBB_BRANCH

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "rxu/AdvancedWarnings",
     "type": "phpbb-extension",
-    "description": "This extension replace built-in warnings system with the more advanced one.",
+    "description": "This extension replaces built-in warnings system with the more advanced one.",
     "homepage": "http://phpbbguru.net",
-    "version": "2.0.0",
-    "time": "2014-03-17",
+    "version": "2.0.1",
+    "time": "2015-07-28",
     "license": "GPL-2.0",
     "authors": [
         {
@@ -22,7 +22,7 @@
     "extra": {
         "display-name": "Advanced warnings",
         "soft-require": {
-           "phpbb/phpbb": "3.1.*@dev"
+           "phpbb/phpbb": "3.1.*"
         }
     }
 }

--- a/event/listener.php
+++ b/event/listener.php
@@ -128,7 +128,7 @@ class listener implements EventSubscriberInterface
 			$warning = unserialize($row['log_data']);
 
 			$user[] = array(
-				'U_EDIT'            => ($this->auth->acl_get('m_warn')) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=\rxu\AdvancedWarnings\mcp\warnings_module&amp;mode=' . (($row['post_id']) ? 'warn_post&amp;p=' . $row['post_id'] : 'warn_user') . '&amp;u=' . $user_id . '&amp;warn_id=' . $row['warning_id']) : '',
+				'U_EDIT'            => ($this->auth->acl_get('m_warn')) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=-rxu-AdvancedWarnings-mcp-warnings_module&amp;mode=' . (($row['post_id']) ? 'warn_post&amp;p=' . $row['post_id'] : 'warn_user') . '&amp;u=' . $user_id . '&amp;warn_id=' . $row['warning_id']) : '',
 
 				'USERNAME_FULL'	    => get_username_string('full', $row['user_id'], $row['username'], $row['user_colour']),
 				'USERNAME_COLOUR'   => ($row['user_colour']) ? '#' . $row['user_colour'] : '',
@@ -153,7 +153,7 @@ class listener implements EventSubscriberInterface
 	{
 		$user_id = (int) $event['data']['user_id'];
 		$template_data = $event['template_data'];
-		$template_data['U_WARN'] = ($this->auth->acl_get('m_warn')) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=\rxu\AdvancedWarnings\mcp\warnings_module&amp;mode=warn_user&amp;u=' . $user_id) : '';
+		$template_data['U_WARN'] = ($this->auth->acl_get('m_warn')) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=-rxu-AdvancedWarnings-mcp-warnings_module&amp;mode=warn_user&amp;u=' . $user_id) : '';
 		$event['template_data'] = $template_data;
 	}
 
@@ -224,7 +224,7 @@ class listener implements EventSubscriberInterface
 			'POSTER_BANNED'		=> (isset($user_cache['user_ban_id']) && $user_cache['user_ban_id']) ? true : ((isset($this->users_banned[$poster_id])) ? true : false),
 			'POSTER_BAN_END'	=> (isset($user_cache['user_ban_id']) && $user_cache['user_ban_id']) ? $this->user->lang('BANNED_BY_X_WARNINGS', (int) $this->config['warnings_for_ban']) : ((isset($this->users_banned[$poster_id])) ? (($this->users_banned[$poster_id]['warning_end'] > 0) ? sprintf($this->user->lang['BANNED_UNTIL'], $this->user->format_date($this->users_banned[$poster_id]['warning_end'])) : $this->user->lang['BANNED_PERMANENTLY']) : ''),
 		));
-		$postrow['U_WARN'] = ($this->auth->acl_get('m_warn') && $poster_id != $this->user->data['user_id'] && $poster_id != ANONYMOUS) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=\rxu\AdvancedWarnings\mcp\warnings_module&amp;mode=warn_post&amp;f=' . $forum_id . '&amp;p=' . $post_id, true, $this->user->session_id) : '';
+		$postrow['U_WARN'] = ($this->auth->acl_get('m_warn') && $poster_id != $this->user->data['user_id'] && $poster_id != ANONYMOUS) ? append_sid("{$this->phpbb_root_path}mcp.$this->php_ext", 'i=-rxu-AdvancedWarnings-mcp-warnings_module&amp;mode=warn_post&amp;f=' . $forum_id . '&amp;p=' . $post_id, true, $this->user->session_id) : '';
 
 		$event['post_row'] = $postrow;
 	}

--- a/migrations/v_2_0_1.php
+++ b/migrations/v_2_0_1.php
@@ -1,0 +1,56 @@
+<?php
+/**
+*
+* Advanced Warnings extension for the phpBB Forum Software package.
+*
+* @copyright (c) 2013 phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+*/
+
+namespace rxu\AdvancedWarnings\migrations;
+
+class v_2_0_1 extends \phpbb\db\migration\migration
+{
+	public function effectively_installed()
+	{
+		return isset($this->config['advanced_warnings_version']) && version_compare($this->config['advanced_warnings_version'], '2.0.1', '>=');
+	}
+
+	static public function depends_on()
+	{
+		return array('\rxu\AdvancedWarnings\migrations\v_2_0_0');
+	}
+
+	public function revert_data()
+	{
+		return array(
+		);
+	}
+
+	public function update_data()
+	{
+		return array(
+			// Current version.
+			array('config.update', array('advanced_warnings_version', '2.0.1')),
+
+			// Replace line breaks to <br />.
+			array('custom', array(array($this, 'update_banlist_table'))),
+			array('custom', array(array($this, 'purge_cache'))),
+		);
+	}
+
+	public function update_banlist_table()
+	{
+		$sql = "UPDATE " . BANLIST_TABLE . "
+			SET ban_reason = REPLACE(REPLACE(ban_reason, '\n', '<br />'), '\r', '<br />'),
+			ban_give_reason = REPLACE(REPLACE(ban_give_reason, '\n', '<br />'), '\r', '<br />')";
+		$this->sql_query($sql);
+	}
+
+	public function purge_cache()
+	{
+		global $cache;
+		$cache->destroy('sql', array(BANLIST_TABLE));
+	}
+}


### PR DESCRIPTION
* Fix for multilined descriptions - they are replaced to `<br />`. Current descriptions should be reparsed manually.
* Replace `\` to `-` in links - according to phpBB style.
* Remove unused global variables.
* Add language file `acp/ban` once in the beginning of the module file.
* No more usages of super globals.